### PR TITLE
[Feature] Documentify 상속에서 인터페이스 delegate 방식으로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
 ```
 
 ### Getting Started
-First, make your test class implements `Documentify` by `Documentify.new()`. and set up the test environment like this:
+First, make your test class implement `Documentify` via delegation (`Documentify.new()`), and set up the test environment like this:
 ```kotlin
 @BeforeEach
 fun setUp(provider: RestDocumentationContextProvider) {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
 ```
 
 ### Getting Started
-First, make your test class extends `Documentify`. and set up the test environment like this:
+First, make your test class implements `Documentify` by `Documentify.new()`. and set up the test environment like this:
 ```kotlin
 @BeforeEach
 fun setUp(provider: RestDocumentationContextProvider) {

--- a/documentify-project/documentify-core/build.gradle.kts
+++ b/documentify-project/documentify-core/build.gradle.kts
@@ -5,4 +5,7 @@ dependencies {
     compileOnly(libs.spring.boot.starter.test)
     compileOnly(libs.spring.restdocs.webtestclient)
     compileOnly(libs.spring.boot.starter.web)
+
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.restdocs.webtestclient)
 }

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/AbstractDocumentifySupport.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/AbstractDocumentifySupport.kt
@@ -11,12 +11,12 @@ import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.context.WebApplicationContext
 
-abstract class AbstractDocumentify {
+abstract class AbstractDocumentifySupport : DocumentifySupport {
     protected lateinit var provider: RestDocumentationContextProvider
     protected lateinit var environment: DocumentContextEnvironment
     protected var customEmitter: DocumentEmitter? = null
 
-    fun documentation(
+    override fun documentation(
         name: String,
         specCustomizer: DocumentSpec.() -> Unit
     ): WebTestClient.BodyContentSpec {
@@ -26,13 +26,13 @@ abstract class AbstractDocumentify {
         return emitter.emit()
     }
 
-    fun emitter(
+    override fun emitter(
         customEmitter: DocumentEmitter
     ) {
         this.customEmitter = customEmitter
     }
 
-    fun webTestClient(
+    override fun webTestClient(
         provider: RestDocumentationContextProvider,
         webTestClient: WebTestClient
     ) {
@@ -40,7 +40,7 @@ abstract class AbstractDocumentify {
         environment = webTestClientEnvironment(provider, webTestClient)
     }
 
-    fun applicationContext(
+    override fun applicationContext(
         provider: RestDocumentationContextProvider,
         applicationContext: ApplicationContext
     ) {
@@ -48,11 +48,13 @@ abstract class AbstractDocumentify {
         environment = applicationContextEnvironment(provider, applicationContext)
     }
 
-    fun webApplicationContext(
+    override fun webApplicationContext(
         provider: RestDocumentationContextProvider,
         context: WebApplicationContext
     ) {
         environment = applicationContextEnvironment(provider, context)
         this.provider = provider
     }
+
+    companion object
 }

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/AbstractDocumentifySupport.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/AbstractDocumentifySupport.kt
@@ -18,10 +18,11 @@ abstract class AbstractDocumentifySupport : DocumentifySupport {
 
     override fun documentation(
         name: String,
+        printOption: PrintOption,
         specCustomizer: DocumentSpec.() -> Unit
     ): WebTestClient.BodyContentSpec {
         val documentSpec = DocumentSpec(name).also { specCustomizer(it) }
-        val emitter = customEmitter ?: EmitterFactory.of(provider, documentSpec, environment)
+        val emitter = customEmitter ?: EmitterFactory.of(provider, documentSpec, environment, printOption)
 
         return emitter.emit()
     }

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/DocumentifySupport.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/DocumentifySupport.kt
@@ -1,0 +1,25 @@
+package io.github.bgmsound.documentify.core
+
+import io.github.bgmsound.documentify.core.emitter.DocumentEmitter
+import io.github.bgmsound.documentify.core.specification.schema.document.DocumentSpec
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationContext
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.context.WebApplicationContext
+
+@ExtendWith(RestDocumentationExtension::class)
+interface DocumentifySupport {
+
+    fun documentation(name: String, specCustomizer: DocumentSpec.() -> Unit): WebTestClient.BodyContentSpec
+
+    fun emitter(customEmitter: DocumentEmitter)
+
+    fun webTestClient(provider: RestDocumentationContextProvider, webTestClient: WebTestClient)
+
+    fun applicationContext(provider: RestDocumentationContextProvider, applicationContext: ApplicationContext)
+
+    fun webApplicationContext(provider: RestDocumentationContextProvider, context: WebApplicationContext)
+
+}

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/DocumentifySupport.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/DocumentifySupport.kt
@@ -12,7 +12,13 @@ import org.springframework.web.context.WebApplicationContext
 @ExtendWith(RestDocumentationExtension::class)
 interface DocumentifySupport {
 
-    fun documentation(name: String, specCustomizer: DocumentSpec.() -> Unit): WebTestClient.BodyContentSpec
+    fun documentation(name: String, specCustomizer: DocumentSpec.() -> Unit): WebTestClient.BodyContentSpec = documentation(name, PrintOption.ON, specCustomizer)
+
+    fun documentation(
+        name: String,
+        printOption: PrintOption,
+        specCustomizer: DocumentSpec.() -> Unit
+    ): WebTestClient.BodyContentSpec
 
     fun emitter(customEmitter: DocumentEmitter)
 

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/PrintOption.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/PrintOption.kt
@@ -1,0 +1,6 @@
+package io.github.bgmsound.documentify.core
+
+enum class PrintOption {
+    ON,
+    OFF,
+}

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DefaultDocumentSpecSampleAggregator.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DefaultDocumentSpecSampleAggregator.kt
@@ -9,44 +9,82 @@ object DefaultDocumentSpecSampleAggregator : DocumentSpecSampleAggregator {
         if (specElements.isEmpty()) {
             return emptyMap()
         }
-        if (!specElements.isField()) {
-            return specElements.associate {
-                it.key to it.sample
-            }
+        if (specElements.any { it !is Field }) {
+            return specElements.associate { it.key to it.sample }
         }
-        val fieldElements = specElements as List<Field>
-        return fieldElements.filter {
-            it.hasSample() || it.canHaveChild() || !it.isIgnored()
-        }.associate {
-            it.aggregateSample()
+        val leaves = collectLeaves(specElements as List<Field>)
+        if (leaves.isEmpty()) {
+            return emptyMap()
         }
+        val entries = leaves.map { (path, sample) ->
+            Entry(parsePath(path), sample)
+        }
+        return assemble(entries) as Map<String, Any>
     }
 
-    private fun Field.aggregateSample(): Pair<String, Any> {
-        if (isIgnored()) {
-            throw IllegalStateException("can't associate ignored field $key")
-        }
-        if (!hasSample() && !canHaveChild()) {
-            throw IllegalStateException("Field $key must have sample or child fields")
-        }
-        return key to if (hasSample()) {
-            sample
-        } else {
-            if (childFields().isEmpty()) {
-                throw IllegalStateException("Field $key must have child fields")
-            }
-            val sample = childFields().associate { it.aggregateSample() }
-            if (isArray()) {
-                listOf(sample)
-            } else {
-                sample
+    private fun collectLeaves(fields: List<Field>): List<Pair<String, Any>> {
+        return fields.flatMap { field ->
+            when {
+                field.isIgnored() -> emptyList()
+                field.hasSample() -> listOf(field.path to field.sample)
+                field.canHaveChild() -> collectLeaves(field.childFields())
+                else -> throw IllegalStateException(
+                    "Field '${field.path}' must have a sample or child fields"
+                )
             }
         }
     }
 
-    private fun List<SpecElement>.isField(): Boolean {
-        return all {
-            it is Field
+    private fun parsePath(path: String): List<PathSegment> {
+        return SEGMENT.findAll(path).fold(emptyList()) { segments, match ->
+            when {
+                match.groups[1] != null -> segments + PathSegment(match.groupValues[1], arrayIndex = null)
+                match.groups[2] != null -> if (segments.isEmpty()) {
+                    segments
+                } else {
+                    segments.dropLast(1) + segments.last()
+                        .copy(arrayIndex = match.groupValues[2].ifEmpty { "0" }.toInt())
+                }
+
+                else -> segments + PathSegment(match.groupValues[3], arrayIndex = null)
+            }
         }
     }
+
+    private fun assemble(entries: List<Entry>, prefix: String = ""): Any {
+        val terminal = entries.firstOrNull { it.segments.isEmpty() }
+        if (terminal != null) {
+            check(entries.all { it.segments.isEmpty() }) {
+                "Conflicting field declaration at '${prefix.ifEmpty { "<root>" }}': " +
+                    "declared as a value and as a parent of nested fields"
+            }
+            return terminal.sample
+        }
+        return entries
+            .groupBy { it.segments.first().name }
+            .mapValues { (name, group) ->
+                val childPrefix = if (prefix.isEmpty()) name else "$prefix.$name"
+                if (group.first().segments.first().arrayIndex == null) {
+                    assemble(group.descend(), childPrefix)
+                } else {
+                    assembleArray(group, childPrefix)
+                }
+            }
+    }
+
+    private fun assembleArray(entries: List<Entry>, prefix: String): List<Any> =
+        entries
+            .groupBy {
+                it.segments.first().arrayIndex ?: error("Conflicting field declaration at '$prefix': mixed array and object notation")
+            }
+            .toSortedMap()
+            .map { (index, indexed) -> assemble(indexed.descend(), "$prefix[$index]") }
+
+    private fun List<Entry>.descend(): List<Entry> =
+        map { Entry(it.segments.drop(1), it.sample) }
+
+    private data class Entry(val segments: List<PathSegment>, val sample: Any)
+    private data class PathSegment(val name: String, val arrayIndex: Int?)
+
+    private val SEGMENT = Regex("""\['([^']*)']|\[(\d*)]|([^.\[\]]+)""")
 }

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DefaultDocumentSpecSampleAggregator.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DefaultDocumentSpecSampleAggregator.kt
@@ -19,7 +19,12 @@ object DefaultDocumentSpecSampleAggregator : DocumentSpecSampleAggregator {
         val entries = leaves.map { (path, sample) ->
             Entry(parsePath(path), sample)
         }
-        return assemble(entries) as Map<String, Any>
+        val assembled = assemble(entries)
+        return if (assembled is Map<*, *>) {
+            assembled as Map<String, Any>
+        } else {
+            mapOf("" to assembled)
+        }
     }
 
     private fun collectLeaves(fields: List<Field>): List<Pair<String, Any>> {

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DocumentSpecSampleAggregator.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/DocumentSpecSampleAggregator.kt
@@ -2,7 +2,7 @@ package io.github.bgmsound.documentify.core.emitter
 
 import io.github.bgmsound.documentify.core.specification.element.SpecElement
 
-interface DocumentSpecSampleAggregator{
+interface DocumentSpecSampleAggregator {
 
     fun <T : SpecElement> aggregate(specElements: List<T>) : Map<String, Any>
 

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/EmitterFactory.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/EmitterFactory.kt
@@ -1,5 +1,6 @@
 package io.github.bgmsound.documentify.core.emitter
 
+import io.github.bgmsound.documentify.core.PrintOption
 import io.github.bgmsound.documentify.core.environment.DocumentContextEnvironment
 import io.github.bgmsound.documentify.core.specification.schema.document.DocumentSpec
 import org.springframework.restdocs.RestDocumentationContextProvider
@@ -8,8 +9,9 @@ object EmitterFactory {
     fun of(
         provider: RestDocumentationContextProvider,
         documentSpec: DocumentSpec,
-        environment: DocumentContextEnvironment
+        environment: DocumentContextEnvironment,
+        printOption: PrintOption
     ): DocumentEmitter {
-        return WebTestClientDocumentEmitter(provider, documentSpec, environment)
+        return WebTestClientDocumentEmitter(provider, documentSpec, environment, printOption)
     }
 }

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/WebTestClientDocumentEmitter.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/WebTestClientDocumentEmitter.kt
@@ -33,10 +33,11 @@ class WebTestClientDocumentEmitter(
         val samplePathVariables = sampleAggregator.aggregate(documentSpec.request.pathVariables)
         val sampleHeaders = sampleAggregator.aggregate(documentSpec.request.headers)
         val sampleFields = sampleAggregator.aggregate(documentSpec.request.fields)
+        val (uriTemplate, queryVariables) = requestUri()
 
         return webTestClient
             .method(method())
-            .uri(requestUri, samplePathVariables)
+            .uri(uriTemplate, samplePathVariables + queryVariables)
             .headers { headers ->
                 headers.addAll(sampleHeaders.toMultiValueMap())
             }
@@ -61,6 +62,8 @@ class WebTestClientDocumentEmitter(
     }
 
     override fun emitAlternativeResponseDocument() {
+        val samplePathVariables = sampleAggregator.aggregate(documentSpec.request.pathVariables)
+        val (uriTemplate, queryVariables) = requestUri()
         documentSpec.otherResponses.forEachIndexed { index, response ->
             val sampleResponseFields = sampleAggregator.aggregate(response.fields)
             val api = AlternativeResponseDocumentController.new(
@@ -73,10 +76,9 @@ class WebTestClientDocumentEmitter(
                 .filter(WebTestClientRestDocumentation.documentationConfiguration(provider))
                 .build()
 
-            val samplePathVariables = sampleAggregator.aggregate(documentSpec.request.pathVariables)
             webTestClient
                 .method(method())
-                .uri(requestUri, samplePathVariables)
+                .uri(uriTemplate, samplePathVariables + queryVariables)
                 .exchange()
                 .expectStatus()
                 .isEqualTo(response.statusCode)
@@ -95,16 +97,16 @@ class WebTestClientDocumentEmitter(
         }
     }
 
-    private val requestUri get(): String {
-        return StringBuilder().apply {
-            append(documentSpec.request.url)
-            if (documentSpec.request.queryParameters.isNotEmpty()) {
-                append("?")
-                append(documentSpec.request.queryParameters.joinToString("&") { parameter ->
-                    "${parameter.key}=${parameter.sample}"
-                })
-            }
-        }.toString()
+    private fun requestUri(): Pair<String, Map<String, Any>> {
+        val queryVariables = mutableMapOf<String, Any>()
+        val template = StringBuilder(documentSpec.request.url)
+        documentSpec.request.queryParameters.forEachIndexed { index, parameter ->
+            val placeholder = "documentifyQuery$index"
+            template.append(if (index == 0) "?" else "&")
+            template.append("${parameter.key}={$placeholder}")
+            queryVariables[placeholder] = parameter.sample
+        }
+        return template.toString() to queryVariables
     }
 
     private fun RequestBodySpec.bodyIfExist(

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/WebTestClientDocumentEmitter.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/emitter/WebTestClientDocumentEmitter.kt
@@ -1,9 +1,11 @@
 package io.github.bgmsound.documentify.core.emitter
 
 
+import io.github.bgmsound.documentify.core.PrintOption
 import io.github.bgmsound.documentify.core.environment.DocumentContextEnvironment
 import io.github.bgmsound.documentify.core.specification.schema.Method
 import io.github.bgmsound.documentify.core.specification.schema.document.DocumentSpec
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpMethod
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.operation.preprocess.Preprocessors.*
@@ -18,11 +20,13 @@ import org.springframework.util.MultiValueMap
 class WebTestClientDocumentEmitter(
     provider: RestDocumentationContextProvider,
     documentSpec: DocumentSpec,
-    environment: DocumentContextEnvironment
+    environment: DocumentContextEnvironment,
+    private val printOption: PrintOption
 ) : AbstractDocumentEmitter(provider, documentSpec) {
     private val webTestClient: WebTestClient = environment.buildTestClient()
     private val requestPreprocessors = environment.requestPreprocessors().toTypedArray()
     private val responsePreprocessors = environment.responsePreprocessors().toTypedArray()
+    private val log = LoggerFactory.getLogger(WebTestClientDocumentEmitter::class.java)
 
     override fun emitDocument(): BodyContentSpec {
         val snippets = documentSpec.build()
@@ -42,7 +46,9 @@ class WebTestClientDocumentEmitter(
             .isEqualTo(documentSpec.response.statusCode)
             .expectBody()
             .consumeWith {
-                println(it)
+                if (printOption == PrintOption.ON) {
+                    log.info("\n{}", it)
+                }
             }
             .consumeWith(
                 document(
@@ -75,7 +81,9 @@ class WebTestClientDocumentEmitter(
                 .expectStatus()
                 .isEqualTo(response.statusCode)
                 .expectBody()
-                .consumeWith { println(it)}
+                .consumeWith {
+                    if (printOption == PrintOption.ON) log.info("\n{}", it)
+                }
                 .consumeWith(
                     document(
                         "${documentSpec.name}-case-${index + 1}",

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/environment/AbstractStandaloneContextEnvironment.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/environment/AbstractStandaloneContextEnvironment.kt
@@ -1,8 +1,10 @@
 package io.github.bgmsound.documentify.core.environment
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.bgmsound.documentify.core.specification.DocumentifyDsl
 import org.springframework.core.convert.converter.Converter
 
+@DocumentifyDsl
 @Suppress("UNCHECKED_CAST")
 abstract class AbstractStandaloneContextEnvironment<T : StandaloneContextEnvironment<T>> : StandaloneContextEnvironment<T>, AbstractDocumentContextEnvironment() {
     protected val controllers: MutableList<Any> = mutableListOf()

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/DocumentableSpec.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/DocumentableSpec.kt
@@ -2,6 +2,7 @@ package io.github.bgmsound.documentify.core.specification
 
 import org.springframework.restdocs.snippet.Snippet
 
+@DocumentifyDsl
 interface DocumentableSpec {
 
     fun build(): List<Snippet>

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/DocumentifyDsl.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/DocumentifyDsl.kt
@@ -1,0 +1,5 @@
+package io.github.bgmsound.documentify.core.specification
+
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+annotation class DocumentifyDsl

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/DocsFieldType.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/DocsFieldType.kt
@@ -3,7 +3,7 @@ package io.github.bgmsound.documentify.core.specification.element.field
 import org.springframework.restdocs.payload.JsonFieldType
 import kotlin.reflect.KClass
 
-sealed class DocsFieldType(val type: JsonFieldType)
+sealed class DocsFieldType(val jsonType: JsonFieldType)
 
 data object ARRAY : DocsFieldType(JsonFieldType.ARRAY)
 data object BOOLEAN : DocsFieldType(JsonFieldType.BOOLEAN)

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
@@ -17,13 +17,17 @@ class Field(
 ) : SpecElement(descriptor), FieldSchema {
     val path: String get() = descriptor.path
 
+    var docsType: DocsFieldType? = null
+        private set
+
     fun childFields(): List<Field> = childFields
 
     infix fun type(type: DocsFieldType): Field {
         check(type == OBJECT || type == ARRAY || childFields.isEmpty()) {
             "Field '$key' has child fields and cannot change to a non-container type"
         }
-        descriptor.type(type.type)
+        descriptor.type(type.jsonType)
+        docsType = type
         return this
     }
 
@@ -44,15 +48,15 @@ class Field(
     }
 
     fun canHaveChild(): Boolean {
-        return descriptor.type == OBJECT.type || descriptor.type == ARRAY.type
+        return descriptor.type == OBJECT.jsonType || descriptor.type == ARRAY.jsonType
     }
 
     fun isObject(): Boolean {
-        return descriptor.type == OBJECT.type
+        return descriptor.type == OBJECT.jsonType
     }
 
     fun isArray(): Boolean {
-        return descriptor.type == ARRAY.type
+        return descriptor.type == ARRAY.jsonType
     }
 
     private fun requireContainer() {
@@ -157,7 +161,7 @@ class Field(
 
     fun buildPath(path: String): String {
         var parent = this.path
-        parent = if (descriptor.type == ARRAY.type) {
+        parent = if (descriptor.type == ARRAY.jsonType) {
             "$parent[]."
         } else if (parent.isNotEmpty() && parent.isNotBlank()) {
             "$parent."
@@ -186,17 +190,21 @@ class Field(
                 Requirement.OPTIONAL -> descriptor.optional()
                 Requirement.IGNORED -> descriptor.ignored()
             }
-            when {
-                sample is Collection<*> || clazz.isArray -> descriptor.type(ARRAY.type)
-                sample is Map<*, *> -> descriptor.type(OBJECT.type)
-                sample is String -> descriptor.type(STRING.type)
-                sample is Enum<*> -> descriptor.type(STRING.type)
-                sample is Boolean -> descriptor.type(BOOLEAN.type)
-                sample is Number -> descriptor.type(NUMBER.type)
-                sample is LocalDate -> descriptor.type(DATE.type)
-                sample is LocalDateTime -> descriptor.type(DATETIME.type)
-            }
-            return Field(descriptor, extractKeyFromPath(path))
+            val field = Field(descriptor, extractKeyFromPath(path))
+            detectType(sample, clazz)?.let { field.type(it) }
+            return field
+        }
+
+        private fun detectType(sample: Any, clazz: Class<*>): DocsFieldType? = when {
+            sample is Collection<*> || clazz.isArray -> ARRAY
+            sample is Map<*, *> -> OBJECT
+            sample is String -> STRING
+            sample is Enum<*> -> STRING
+            sample is Boolean -> BOOLEAN
+            sample is Number -> NUMBER
+            sample is LocalDate -> DATE
+            sample is LocalDateTime -> DATETIME
+            else -> null
         }
 
         fun newField(path: String, description: String, requirement: Requirement): Field {

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
@@ -1,11 +1,13 @@
 package io.github.bgmsound.documentify.core.specification.element.field
 
+import io.github.bgmsound.documentify.core.specification.DocumentifyDsl
 import io.github.bgmsound.documentify.core.specification.FieldSchema
 import io.github.bgmsound.documentify.core.specification.element.SpecElement
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.snippet.Attributes
 
+@DocumentifyDsl
 class Field(
     private val descriptor: FieldDescriptor,
     override val key: String,

--- a/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
+++ b/documentify-project/documentify-core/src/main/kotlin/io/github/bgmsound/documentify/core/specification/element/field/Field.kt
@@ -6,6 +6,8 @@ import io.github.bgmsound.documentify.core.specification.element.SpecElement
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.snippet.Attributes
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @DocumentifyDsl
 class Field(
@@ -18,6 +20,9 @@ class Field(
     fun childFields(): List<Field> = childFields
 
     infix fun type(type: DocsFieldType): Field {
+        check(type == OBJECT || type == ARRAY || childFields.isEmpty()) {
+            "Field '$key' has child fields and cannot change to a non-container type"
+        }
         descriptor.type(type.type)
         return this
     }
@@ -50,6 +55,10 @@ class Field(
         return descriptor.type == ARRAY.type
     }
 
+    private fun requireContainer() {
+        check(canHaveChild()) { "Field '$key' must be an object or array to have child fields" }
+    }
+
     infix fun with(childFieldsCustomizer: Field.() -> Unit): Field {
         childFieldsCustomizer.invoke(this)
         return this
@@ -57,16 +66,12 @@ class Field(
 
     fun type(type: DocsFieldType, childFieldsCustomizer: Field.() -> Unit): Field {
         type(type)
-        if (!canHaveChild()) {
-            throw IllegalArgumentException("Field $key can't have child fields")
-        }
+        requireContainer()
         return with(childFieldsCustomizer)
     }
 
-    fun childField(field: Field): Field {
-        if (!canHaveChild()) {
-            throw IllegalArgumentException("Field $key can't have child fields")
-        }
+    private fun childField(field: Field): Field {
+        requireContainer()
         childFields.add(field)
         return field
     }
@@ -76,7 +81,7 @@ class Field(
     }
 
     override fun field(path: String, description: String, sample: Any, childFields: Field.() -> Unit): Field {
-        val field = newField(path.javaClass, buildPath(path), description, sample, Requirement.REQUIRED)
+        val field = newField(sample.javaClass, buildPath(path), description, sample, Requirement.REQUIRED)
         return childField(field).with(childFields)
     }
 
@@ -144,9 +149,6 @@ class Field(
     }
 
     fun build(): List<FieldDescriptor> {
-        if (!canHaveChild() && childFields.isNotEmpty()) {
-            throw IllegalStateException("Field $key can't have child fields")
-        }
         return buildList {
             add(descriptor)
             childFields.forEach { addAll(it.build()) }
@@ -184,12 +186,15 @@ class Field(
                 Requirement.OPTIONAL -> descriptor.optional()
                 Requirement.IGNORED -> descriptor.ignored()
             }
-            if (sample is Collection<*> || clazz.isArray) {
-                descriptor.type(ARRAY.type)
-            } else if (sample is Map<*, *>) {
-                descriptor.type(OBJECT.type)
-            } else if (sample is String) {
-                descriptor.type(STRING.type)
+            when {
+                sample is Collection<*> || clazz.isArray -> descriptor.type(ARRAY.type)
+                sample is Map<*, *> -> descriptor.type(OBJECT.type)
+                sample is String -> descriptor.type(STRING.type)
+                sample is Enum<*> -> descriptor.type(STRING.type)
+                sample is Boolean -> descriptor.type(BOOLEAN.type)
+                sample is Number -> descriptor.type(NUMBER.type)
+                sample is LocalDate -> descriptor.type(DATE.type)
+                sample is LocalDateTime -> descriptor.type(DATETIME.type)
             }
             return Field(descriptor, extractKeyFromPath(path))
         }
@@ -206,15 +211,11 @@ class Field(
             return Field(descriptor, extractKeyFromPath(path))
         }
 
+        private val BRACKET_KEY = Regex("""\['([^']*)']$""")
+
         private fun extractKeyFromPath(path: String): String {
-            val lastKey = path.substringAfterLast(".")
-            val parentKey = path.substringBeforeLast(".")
-            return if (lastKey.contains("'")) {
-                val parentKeyLast = parentKey.substringAfterLast(".")
-                "$parentKeyLast.$lastKey"
-            } else {
-                lastKey
-            }
+            BRACKET_KEY.find(path)?.let { return it.groupValues[1] }
+            return path.substringAfterLast(".").substringBefore("[")
         }
     }
 }

--- a/documentify-project/documentify-core/src/test/kotlin/io/github/bgmsound/documentify/core/FieldTest.kt
+++ b/documentify-project/documentify-core/src/test/kotlin/io/github/bgmsound/documentify/core/FieldTest.kt
@@ -1,0 +1,99 @@
+package io.github.bgmsound.documentify.core
+
+import io.github.bgmsound.documentify.core.specification.element.field.STRING
+import io.github.bgmsound.documentify.core.specification.schema.response.ResponseBodySpec
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.restdocs.payload.JsonFieldType
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class FieldTest {
+
+    @Test
+    fun `top level array sample is detected as array`() {
+        val tags = ResponseBodySpec().field("tags", "tags", arrayOf("a", "b"))
+
+        assertThat(tags.isArray()).isTrue()
+    }
+
+    @Test
+    fun `nested list sample is detected as array`() {
+        val body = ResponseBodySpec().apply {
+            objectField("outer", "outer") {
+                field("tags", "tags", listOf("a", "b"))
+            }
+        }
+        val tags = body.fields().single().childFields().single()
+
+        assertThat(tags.isArray()).isTrue()
+    }
+
+    @Test
+    fun `nested array sample is detected as array`() {
+        val body = ResponseBodySpec().apply {
+            objectField("outer", "outer") {
+                field("tags", "tags", arrayOf("a", "b"))
+            }
+        }
+        val tags = body.fields().single().childFields().single()
+
+        assertThat(tags.isArray()).isTrue()
+    }
+
+    @Test
+    fun `boolean sample is detected as boolean`() {
+        val flag = ResponseBodySpec().field("flag", "flag", true)
+
+        assertThat(flag.build().single().type).isEqualTo(JsonFieldType.BOOLEAN)
+    }
+
+    @Test
+    fun `number sample is detected as number`() {
+        val count = ResponseBodySpec().field("count", "count", 42)
+
+        assertThat(count.build().single().type).isEqualTo(JsonFieldType.NUMBER)
+    }
+
+    @Test
+    fun `local date sample is detected as string`() {
+        val date = ResponseBodySpec().field("date", "date", LocalDate.of(2024, 1, 1))
+
+        assertThat(date.build().single().type).isEqualTo(JsonFieldType.STRING)
+    }
+
+    @Test
+    fun `local date time sample is detected as string`() {
+        val dateTime = ResponseBodySpec().field("dateTime", "dateTime", LocalDateTime.of(2024, 1, 1, 0, 0))
+
+        assertThat(dateTime.build().single().type).isEqualTo(JsonFieldType.STRING)
+    }
+
+    @Test
+    fun `enum sample is detected as string`() {
+        val color = ResponseBodySpec().field("color", "color", Color.RED)
+
+        assertThat(color.build().single().type).isEqualTo(JsonFieldType.STRING)
+    }
+
+    @Test
+    fun `adding a child to a scalar field throws`() {
+        val name = ResponseBodySpec().field("name", "name", "John")
+
+        assertThatThrownBy { name.field("child", "child", "x") }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `changing a populated container to a scalar type throws`() {
+        val outer = ResponseBodySpec().objectField("outer", "outer") {
+            field("inner", "inner", "x")
+        }
+
+        assertThatThrownBy { outer.type(STRING) }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    private enum class Color { RED, BLUE }
+}

--- a/documentify-project/documentify-core/src/test/kotlin/io/github/bgmsound/documentify/core/SpecElementAggregatorTest.kt
+++ b/documentify-project/documentify-core/src/test/kotlin/io/github/bgmsound/documentify/core/SpecElementAggregatorTest.kt
@@ -1,0 +1,172 @@
+package io.github.bgmsound.documentify.core
+
+import io.github.bgmsound.documentify.core.emitter.DefaultDocumentSpecSampleAggregator
+import io.github.bgmsound.documentify.core.specification.schema.response.ResponseBodySpec
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class SpecElementAggregatorTest {
+
+    private fun ResponseBodySpec.aggregated(): Map<String, Any> =
+        DefaultDocumentSpecSampleAggregator.aggregate(fields())
+
+    @Test
+    fun `flat scalar fields are aggregated as a flat map`() {
+        val result = ResponseBodySpec().apply {
+            field("id", "id", 1)
+            field("name", "name", "John")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("id" to 1, "name" to "John"))
+    }
+
+    @Test
+    fun `nested object dsl is aggregated as a nested map`() {
+        val result = ResponseBodySpec().apply {
+            objectField("user", "user") {
+                field("name", "name", "John")
+                field("age", "age", 30)
+            }
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("user" to mapOf("name" to "John", "age" to 30)))
+    }
+
+    @Test
+    fun `nested array dsl is aggregated as a single element list`() {
+        val result = ResponseBodySpec().apply {
+            arrayField("items", "items") {
+                field("id", "id", 1)
+                field("label", "label", "first")
+            }
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("items" to listOf(mapOf("id" to 1, "label" to "first"))))
+    }
+
+    @Test
+    fun `optional field with sample is included`() {
+        val result = ResponseBodySpec().apply {
+            field("id", "id", 1)
+            optionalField("nickname", "nickname", "JJ")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("id" to 1, "nickname" to "JJ"))
+    }
+
+    @Test
+    fun `ignored field with sample is excluded`() {
+        val result = ResponseBodySpec().apply {
+            field("id", "id", 1)
+            ignoreField("secret", "secret", "hidden-value")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("id" to 1))
+    }
+
+    @Test
+    fun `nested ignored field is excluded`() {
+        val result = ResponseBodySpec().apply {
+            objectField("user", "user") {
+                field("name", "name", "John")
+                ignoreField("password", "password")
+            }
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("user" to mapOf("name" to "John")))
+    }
+
+    @Test
+    fun `flat jsonpath builds nested structure`() {
+        val result = ResponseBodySpec().apply {
+            field("user.name", "name", "John")
+            field("user.age", "age", 30)
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("user" to mapOf("name" to "John", "age" to 30)))
+    }
+
+    @Test
+    fun `flat jsonpath array notation builds list structure`() {
+        val result = ResponseBodySpec().apply {
+            field("items[].id", "id", 1)
+            field("items[].label", "label", "first")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("items" to listOf(mapOf("id" to 1, "label" to "first"))))
+    }
+
+    @Test
+    fun `flat and nested fields for the same object are merged`() {
+        val result = ResponseBodySpec().apply {
+            field("user.name", "name", "John")
+            objectField("user", "user") {
+                field("age", "age", 30)
+            }
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("user" to mapOf("name" to "John", "age" to 30)))
+    }
+
+    @Test
+    fun `field declared as both value and parent throws`() {
+        val body = ResponseBodySpec().apply {
+            field("user", "user", "literal")
+            field("user.name", "name", "John")
+        }
+
+        assertThatThrownBy { body.aggregated() }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `field without sample throws`() {
+        val body = ResponseBodySpec().apply {
+            field("name", "name")
+        }
+
+        assertThatThrownBy { body.aggregated() }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `bracket quoted key with a dot is treated as a single key`() {
+        val result = ResponseBodySpec().apply {
+            field("data['a.b']", "a.b", "value")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(mapOf("data" to mapOf("a.b" to "value")))
+    }
+
+    @Test
+    fun `indexed array notation builds a multi element list`() {
+        val result = ResponseBodySpec().apply {
+            field("items[0].id", "id", 1)
+            field("items[0].name", "name", "a")
+            field("items[1].id", "id", 2)
+            field("items[1].name", "name", "b")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(
+            mapOf(
+                "items" to listOf(
+                    mapOf("id" to 1, "name" to "a"),
+                    mapOf("id" to 2, "name" to "b"),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `empty bracket and zero index collapse to the same element`() {
+        val result = ResponseBodySpec().apply {
+            field("items[].id", "id", 1)
+            field("items[0].name", "name", "a")
+        }.aggregated()
+
+        assertThat(result).isEqualTo(
+            mapOf("items" to listOf(mapOf("id" to 1, "name" to "a")))
+        )
+    }
+}

--- a/documentify-project/documentify-mvc/src/main/kotlin/io/github/bgmsound/documentify/mvc/Documentify.kt
+++ b/documentify-project/documentify-mvc/src/main/kotlin/io/github/bgmsound/documentify/mvc/Documentify.kt
@@ -1,38 +1,21 @@
 package io.github.bgmsound.documentify.mvc
 
-import io.github.bgmsound.documentify.core.AbstractDocumentify
-import io.github.bgmsound.documentify.mvc.environment.MockMvcContextEnvironment.Companion.mockMvcEnvironment
+import io.github.bgmsound.documentify.core.DocumentifySupport
 import io.github.bgmsound.documentify.mvc.environment.StandaloneMvcContextEnvironment
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.restdocs.RestDocumentationContextProvider
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.test.web.servlet.MockMvc
 
-@ExtendWith(RestDocumentationExtension::class)
-abstract class Documentify : AbstractDocumentify() {
-    fun mockMvc(
-        provider: RestDocumentationContextProvider,
-        mockMvc: MockMvc
-    ) {
-        this.provider = provider
-        environment = mockMvcEnvironment(provider, mockMvc)
+interface Documentify : DocumentifySupport {
+
+    fun mockMvc(provider: RestDocumentationContextProvider, mockMvc: MockMvc)
+
+    fun standalone(provider: RestDocumentationContextProvider, standaloneContext: StandaloneMvcContextEnvironment)
+
+    fun standalone(provider: RestDocumentationContextProvider, contextCustomizer: StandaloneMvcContextEnvironment.() -> Unit)
+
+    companion object {
+
+        fun new(): Documentify = MvcDocumentify()
     }
 
-    fun standalone(
-        provider: RestDocumentationContextProvider,
-        standaloneContext: StandaloneMvcContextEnvironment
-    ) {
-        this.provider = provider
-        environment = standaloneContext
-    }
-
-    fun standalone(
-        provider: RestDocumentationContextProvider,
-        contextCustomizer: StandaloneMvcContextEnvironment.() -> Unit
-    ) {
-        val standaloneContext = StandaloneMvcContextEnvironment
-            .standaloneEnvironment(provider)
-            .also(contextCustomizer)
-        standalone(provider, standaloneContext)
-    }
 }

--- a/documentify-project/documentify-mvc/src/main/kotlin/io/github/bgmsound/documentify/mvc/MvcDocumentify.kt
+++ b/documentify-project/documentify-mvc/src/main/kotlin/io/github/bgmsound/documentify/mvc/MvcDocumentify.kt
@@ -1,0 +1,35 @@
+package io.github.bgmsound.documentify.mvc
+
+import io.github.bgmsound.documentify.core.AbstractDocumentifySupport
+import io.github.bgmsound.documentify.mvc.environment.MockMvcContextEnvironment.Companion.mockMvcEnvironment
+import io.github.bgmsound.documentify.mvc.environment.StandaloneMvcContextEnvironment
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.test.web.servlet.MockMvc
+
+internal class MvcDocumentify : AbstractDocumentifySupport(), Documentify {
+    override fun mockMvc(
+        provider: RestDocumentationContextProvider,
+        mockMvc: MockMvc
+    ) {
+        this.provider = provider
+        environment = mockMvcEnvironment(provider, mockMvc)
+    }
+
+    override fun standalone(
+        provider: RestDocumentationContextProvider,
+        standaloneContext: StandaloneMvcContextEnvironment
+    ) {
+        this.provider = provider
+        environment = standaloneContext
+    }
+
+    override fun standalone(
+        provider: RestDocumentationContextProvider,
+        contextCustomizer: StandaloneMvcContextEnvironment.() -> Unit
+    ) {
+        val standaloneContext = StandaloneMvcContextEnvironment
+            .standaloneEnvironment(provider)
+            .also(contextCustomizer)
+        standalone(provider, standaloneContext)
+    }
+}

--- a/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/Documentify.kt
+++ b/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/Documentify.kt
@@ -1,27 +1,18 @@
 package io.github.bgmsound.documentify.reactive
 
-import io.github.bgmsound.documentify.core.AbstractDocumentify
+import io.github.bgmsound.documentify.core.DocumentifySupport
 import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveContextEnvironment
-import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveContextEnvironment.Companion.standaloneEnvironment
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.restdocs.RestDocumentationContextProvider
-import org.springframework.restdocs.RestDocumentationExtension
 
-@ExtendWith(RestDocumentationExtension::class)
-abstract class Documentify : AbstractDocumentify() {
-    fun standalone(
-        provider: RestDocumentationContextProvider,
-        standaloneContext: StandaloneReactiveContextEnvironment
-    ) {
-        this.provider = provider
-        environment = standaloneContext
+interface Documentify : DocumentifySupport {
+
+    fun standalone(provider: RestDocumentationContextProvider, standaloneContext: StandaloneReactiveContextEnvironment)
+
+    fun standalone(provider: RestDocumentationContextProvider, contextCustomizer: StandaloneReactiveContextEnvironment.() -> Unit)
+
+    companion object {
+
+        fun new(): Documentify = ReactiveDocumentify()
     }
 
-    fun standalone(
-        provider: RestDocumentationContextProvider,
-        contextCustomizer: StandaloneReactiveContextEnvironment.() -> Unit
-    ) {
-        val standaloneContext = standaloneEnvironment(provider).also(contextCustomizer)
-        standalone(provider, standaloneContext)
-    }
 }

--- a/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/ReactiveDocumentify.kt
+++ b/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/ReactiveDocumentify.kt
@@ -1,0 +1,24 @@
+package io.github.bgmsound.documentify.reactive
+
+import io.github.bgmsound.documentify.core.AbstractDocumentifySupport
+import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveContextEnvironment
+import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveContextEnvironment.Companion.standaloneEnvironment
+import org.springframework.restdocs.RestDocumentationContextProvider
+
+class ReactiveDocumentify : AbstractDocumentifySupport(), Documentify {
+    override fun standalone(
+        provider: RestDocumentationContextProvider,
+        standaloneContext: StandaloneReactiveContextEnvironment
+    ) {
+        this.provider = provider
+        environment = standaloneContext
+    }
+
+    override fun standalone(
+        provider: RestDocumentationContextProvider,
+        contextCustomizer: StandaloneReactiveContextEnvironment.() -> Unit
+    ) {
+        val standaloneContext = standaloneEnvironment(provider).also(contextCustomizer)
+        standalone(provider, standaloneContext)
+    }
+}

--- a/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/ReactiveDocumentify.kt
+++ b/documentify-project/documentify-reactive/src/main/kotlin/io/github/bgmsound/documentify/reactive/ReactiveDocumentify.kt
@@ -5,7 +5,7 @@ import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveCon
 import io.github.bgmsound.documentify.reactive.environment.StandaloneReactiveContextEnvironment.Companion.standaloneEnvironment
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class ReactiveDocumentify : AbstractDocumentifySupport(), Documentify {
+internal class ReactiveDocumentify : AbstractDocumentifySupport(), Documentify {
     override fun standalone(
         provider: RestDocumentationContextProvider,
         standaloneContext: StandaloneReactiveContextEnvironment

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ComplexSampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ComplexSampleDocs.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class ComplexSampleDocs : Documentify() {
+class ComplexSampleDocs : Documentify by Documentify.new() {
     private val api = ComplexSampleController()
 
     @BeforeEach

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/DateParseSampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/DateParseSampleDocs.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class DateParseSampleDocs : Documentify() {
+class DateParseSampleDocs : Documentify by Documentify.new() {
     private val api = DateParseSampleController()
 
     @BeforeEach

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ErrorDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ErrorDocs.kt
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
 class ErrorDocs : Documentify by Documentify.new() {
+    private val api = ErrorController()
+
     @BeforeEach
     fun setUp(provider: RestDocumentationContextProvider) {
         standalone(provider) {
-            controller(ErrorController())
+            controller(api)
         }
     }
-
 
     @Test
     fun sampleGetApi() {

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ErrorDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/ErrorDocs.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class ErrorDocs : Documentify() {
+class ErrorDocs : Documentify by Documentify.new() {
     @BeforeEach
     fun setUp(provider: RestDocumentationContextProvider) {
         standalone(provider) {

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/NestedSampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/NestedSampleDocs.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class NestedSampleDocs : Documentify() {
+class NestedSampleDocs : Documentify by Documentify.new() {
     private val api = NestedSampleController()
 
     @BeforeEach

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/SampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/SampleDocs.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class SampleDocs : Documentify() {
+class SampleDocs : Documentify by Documentify.new() {
     private val api = SampleController()
 
     @BeforeEach

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/SnakeSampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/SnakeSampleDocs.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class SnakeSampleDocs : Documentify() {
+class SnakeSampleDocs : Documentify by Documentify.new() {
     private val api = SampleController()
     private val objectMapper = ObjectMapper().apply {
         propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/UnnestedSampleDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/UnnestedSampleDocs.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class UnnestedSampleDocs : Documentify() {
+class UnnestedSampleDocs : Documentify by Documentify.new() {
     private val api = UnnestedSampleController()
 
     @BeforeEach

--- a/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/UseCaseBindingDocs.kt
+++ b/documentify-sample/mvc-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/mvc/documentation/UseCaseBindingDocs.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class UseCaseBindingDocs : Documentify() {
+class UseCaseBindingDocs : Documentify by Documentify.new() {
     private val useCase = mockk<UseCase>()
     private val api = UseCaseBindingController(useCase)
 

--- a/documentify-sample/reactive-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/reactive/documentation/SampleDocs.kt
+++ b/documentify-sample/reactive-sample/src/test/kotlin/io/github/bgmsound/documentify/sample/reactive/documentation/SampleDocs.kt
@@ -1,6 +1,5 @@
 package io.github.bgmsound.documentify.sample.reactive.documentation
 
-
 import io.github.bgmsound.documentify.core.specification.schema.Method
 import io.github.bgmsound.documentify.reactive.Documentify
 import io.github.bgmsound.documentify.sample.reactive.controller.SampleController
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.restdocs.RestDocumentationContextProvider
 
-class SampleDocs : Documentify() {
+class SampleDocs : Documentify by Documentify.new() {
     private val api = SampleController()
 
     @BeforeEach

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 project.name=documentify
 
 project.group=io.github.bgmsound
-project.version.id=1.3.10
+project.version.id=1.4.0
 project.artifact=documentify
 
 project.description=Documentify is a tool to generate API documentation from source code.


### PR DESCRIPTION
[New]
- Documentify 상속 방식에서 인터페이스 delegate 방식으로 전환
- slf4j를 이용한 로그 추상화
- dsl 마커 추가
- 결과 프린트 옵션 enum 추가
- json field path 지원

[Fix]
- Field aggregate 과정에서 list대응 안되는 문제 해결